### PR TITLE
add tomoscan url, base url

### DIFF
--- a/networks/devnet/main/03tomomaster.yml
+++ b/networks/devnet/main/03tomomaster.yml
@@ -8,6 +8,8 @@ services:
       BC_RPC: 'https://devnet.tomochain.com:443'
       BC_NETWORK_ID: 90
       EXPLORER_URL: 'https://scan.devnet.tomochain.com'
+      TOMOSCAN_URL: 'https://scan.devnet.tomochain.com'
+      BASE_URL: 'https://master.devnet.tomochain.com'
       DB_URI: 'mongodb://tomomaster_db:27017/governance'
       GRAFANA_URL: 'https://grafana.devnet.tomochain.com'
     deploy:

--- a/networks/devnet/main/03tomomaster.yml
+++ b/networks/devnet/main/03tomomaster.yml
@@ -8,7 +8,7 @@ services:
       BC_RPC: 'https://devnet.tomochain.com:443'
       BC_NETWORK_ID: 90
       EXPLORER_URL: 'https://scan.devnet.tomochain.com'
-      TOMOSCAN_URL: 'https://scan.devnet.tomochain.com'
+      TOMOSCAN_URL: 'http://tomoscan_server:3333'
       BASE_URL: 'https://master.devnet.tomochain.com'
       DB_URI: 'mongodb://tomomaster_db:27017/governance'
       GRAFANA_URL: 'https://grafana.devnet.tomochain.com'


### PR DESCRIPTION
tomoscan_url is tomoscan api url
https://github.com/tomochain/tomomaster/blob/c9ca3224dc8f526aef670ea5fb6f11adf740ca89/config/custom-environment-variables.json#L13
https://github.com/tomochain/tomomaster/blob/c9ca3224dc8f526aef670ea5fb6f11adf740ca89/config/custom-environment-variables.json#L12

TomoMaster will internally call tomoscan apis via tomoscan_url, so you can use service name instead of domain name