### PR TITLE
Add ANNOUNCE_TXS env to masternodes

### DIFF
--- a/networks/devnet/main/02masternodes.yml
+++ b/networks/devnet/main/02masternodes.yml
@@ -14,6 +14,7 @@ services:
       NETSTATS_HOST: stats.devnet.tomochain.com
       NETSTATS_PORT: 443
       WS_SECRET_FILE: /run/secrets/netstats_ws_secret
+      ANNOUNCE_TXS: true
     ports:
       - target: 30303
         published: 30303
@@ -55,6 +56,7 @@ services:
       NETSTATS_HOST: stats.devnet.tomochain.com
       NETSTATS_PORT: 443
       WS_SECRET_FILE: /run/secrets/netstats_ws_secret
+      ANNOUNCE_TXS: true
     ports:
       - target: 30303
         published: 30303
@@ -96,6 +98,7 @@ services:
       NETSTATS_HOST: stats.devnet.tomochain.com
       NETSTATS_PORT: 443
       WS_SECRET_FILE: /run/secrets/netstats_ws_secret
+      ANNOUNCE_TXS: true
     ports:
       - target: 30303
         published: 30303

--- a/networks/mainnet/main/02masternodes.yml
+++ b/networks/mainnet/main/02masternodes.yml
@@ -14,6 +14,7 @@ services:
       NETSTATS_HOST: stats.tomochain.com
       NETSTATS_PORT: 443
       WS_SECRET_FILE: /run/secrets/netstats_ws_secret
+      ANNOUNCE_TXS: true
     ports:
       - target: 30303
         published: 30303
@@ -55,6 +56,7 @@ services:
       NETSTATS_HOST: stats.tomochain.com
       NETSTATS_PORT: 443
       WS_SECRET_FILE: /run/secrets/netstats_ws_secret
+      ANNOUNCE_TXS: true
     ports:
       - target: 30303
         published: 30303
@@ -96,6 +98,7 @@ services:
       NETSTATS_HOST: stats.tomochain.com
       NETSTATS_PORT: 443
       WS_SECRET_FILE: /run/secrets/netstats_ws_secret
+      ANNOUNCE_TXS: true
     ports:
       - target: 30303
         published: 30303

--- a/networks/testnet/earth/02masternodes.yml
+++ b/networks/testnet/earth/02masternodes.yml
@@ -24,6 +24,7 @@ services:
       NETSTATS_HOST: stats.testnet.tomochain.com
       NETSTATS_PORT: 443
       WS_SECRET_FILE: /run/secrets/netstats_ws_secret
+      ANNOUNCE_TXS: true
     ports:
       - target: 30303
         published: 30303

--- a/networks/testnet/moon/02masternodes.yml
+++ b/networks/testnet/moon/02masternodes.yml
@@ -24,6 +24,7 @@ services:
       NETSTATS_HOST: stats.testnet.tomochain.com
       NETSTATS_PORT: 443
       WS_SECRET_FILE: /run/secrets/netstats_ws_secret
+      ANNOUNCE_TXS: true
     ports:
       - target: 30303
         published: 30303

--- a/networks/testnet/sun/02masternodes.yml
+++ b/networks/testnet/sun/02masternodes.yml
@@ -24,6 +24,7 @@ services:
       NETSTATS_HOST: stats.testnet.tomochain.com
       NETSTATS_PORT: 443
       WS_SECRET_FILE: /run/secrets/netstats_ws_secret
+      ANNOUNCE_TXS: true
     ports:
       - target: 30303
         published: 30303


### PR DESCRIPTION
Add the env var to all the masternodes in devnet/testnet/mainnet to enable TXs announcements after https://github.com/tomochain/tomochain/pull/341 is merged.
It follows https://github.com/tomochain/tomochain/pull/342 who added this to the docker entrypoint.
Testnet don't need it but at least it's already here and will not cause problem with the current configuration (it's just a env var).